### PR TITLE
Add basic VETTOOTH HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# TESTE
+# VETTOOTH Backend (Simplificado)
+
+Este repositório contém um servidor HTTP básico em Node.js que simula rotas para um aplicativo de odontologia.
+
+## Rotas Disponíveis
+- `/patients` – lista de pacientes
+- `/inventory` – itens do estoque
+- `/appointments` – agenda
+- `/prices` – tabela de preços
+
+## Executar
+```
+node index.js
+```
+O servidor roda na porta `3000` por padrão.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,25 @@
+const http = require('http');
+const url = require('url');
+
+const routes = {
+  '/patients': { data: [] },
+  '/inventory': { data: [] },
+  '/appointments': { data: [] },
+  '/prices': { data: [] }
+};
+
+const server = http.createServer((req, res) => {
+  const path = url.parse(req.url).pathname;
+  if (routes[path]) {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(routes[path]));
+  } else {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Rota não encontrada' }));
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Servidor VETTOOTH rodando na porta ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "teste",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- add simple Node.js server with placeholder routes
- document how to run the server

## Testing
- `node index.js`
- `curl -s http://localhost:3000/patients`

##npm install
npx expo start --tunnel
# escaneie o QR no app Expo Go




------
https://chatgpt.com/codex/tasks/task_e_68980fb1694c8323b71520bcca05a44a
